### PR TITLE
add full STX auction contract with bidding logic, reserve enforcement and auction lifecycle controls

### DIFF
--- a/contracts/STXExchange.clar
+++ b/contracts/STXExchange.clar
@@ -2,14 +2,151 @@
 ;; STXExchange
 ;; <add a description here>
 
+;; title: stx-auction
+;; version:
+;; summary:
+;; description:
+;; Error codes
+(define-constant ERR-NOT-AUTHORIZED (err u100))
+(define-constant ERR-AUCTION-ALREADY-STARTED (err u101))
+(define-constant ERR-AUCTION-NOT-STARTED (err u102))
+(define-constant ERR-AUCTION-ENDED (err u103))
+(define-constant ERR-BID-TOO-LOW (err u104))
+(define-constant ERR-TRANSFER-FAILED (err u105))
+(define-constant ERR-AUCTION-NOT-ENDED (err u106))
+(define-constant ERR-NO-BIDS (err u107))
+(define-constant ERR-INVALID-DURATION (err u108))
+(define-constant ERR-RESERVE-NOT-MET (err u109))
+(define-constant ERR-AUCTION-IN-PROGRESS (err u110))
+(define-constant ERR-INVALID-NAME-LENGTH (err u111))
+(define-constant ERR-INVALID-RESERVE-PRICE (err u112))
+
+;; traits
+;;
+;; Define the data for the auction
+(define-data-var top-bid uint u0)
+(define-data-var top-bidder (optional principal) none)
+(define-data-var auction-start-block uint u0)
+(define-data-var auction-end-block uint u0)
+(define-data-var owner principal tx-sender)
+(define-data-var item-name (string-ascii 50) "")
+(define-data-var reserve-price uint u0)
+
+;; token definitions
+;;
+;; Define a constant for minimum bid increment
+(define-constant BID-STEP u1000000) ;; 1 STX
+
 ;; constants
 ;;
+;; Function to start the auction
+(define-public (initialize-auction (duration uint) (name (string-ascii 50)) (min-price uint))
+  (begin
+    ;; Check that the sender is authorized
+    (asserts! (is-eq tx-sender (var-get owner)) ERR-NOT-AUTHORIZED)
+    ;; Check that the auction hasn't started yet
+    (asserts! (is-eq (var-get auction-start-block) u0) ERR-AUCTION-ALREADY-STARTED)
+    ;; Check that the duration is valid
+    (asserts! (> duration u0) ERR-INVALID-DURATION)
+    ;; Check that the item name is not empty and is within the 50-character limit
+    (asserts! (> (len name) u0) ERR-INVALID-NAME-LENGTH)
+    (asserts! (<= (len name) u50) ERR-INVALID-NAME-LENGTH)
+    ;; Check that the minimum price is positive
+    (asserts! (> min-price u0) ERR-INVALID-RESERVE-PRICE)
+    ;; Initialize auction variables
+    (var-set auction-start-block block-height)
+    (var-set auction-end-block (+ block-height duration))
+    (var-set item-name name)
+    (var-set reserve-price min-price)
+    (ok true)))
 
-;; data maps and vars
+;; data vars
 ;;
+;; Function to place a bid
+(define-public (submit-bid (offer uint))
+  (let (
+    (current-offer (var-get top-bid))
+    (min-valid-bid (if (> current-offer (var-get reserve-price))
+                       (+ current-offer BID-STEP)
+                       (var-get reserve-price))))
+    ;; Ensure auction has started
+    (asserts! (> (var-get auction-start-block) u0) ERR-AUCTION-NOT-STARTED)
+    ;; Ensure auction hasn't ended
+    (asserts! (< block-height (var-get auction-end-block)) ERR-AUCTION-ENDED)
+    ;; Ensure bid is valid
+    (asserts! (>= offer min-valid-bid) ERR-BID-TOO-LOW)
+    ;; Transfer the bid and update top-bidder
+    (match (stx-transfer? offer tx-sender (as-contract tx-sender))
+      success
+        (match (var-get top-bidder)
+          previous-leader 
+            (begin
+              (try! (as-contract (stx-transfer? current-offer (as-contract tx-sender) previous-leader)))
+              (var-set top-bid offer)
+              (var-set top-bidder (some tx-sender))
+              (ok true))
+          (begin
+            (var-set top-bid offer)
+            (var-set top-bidder (some tx-sender))
+            (ok true)))
+      error ERR-TRANSFER-FAILED)))
 
-;; private functions
+;; data maps
 ;;
+;; Function to end the auction and transfer funds to the owner
+(define-public (conclude-auction)
+  (begin
+    ;; Ensure auction has ended
+    (asserts! (>= block-height (var-get auction-end-block)) ERR-AUCTION-NOT-ENDED)
+    ;; Ensure there's a valid bid
+    (asserts! (is-some (var-get top-bidder)) ERR-NO-BIDS)
+    ;; Ensure reserve price is met
+    (asserts! (>= (var-get top-bid) (var-get reserve-price)) ERR-RESERVE-NOT-MET)
+    ;; Transfer funds to the owner
+    (match (var-get top-bidder)
+      auction-winner
+        (as-contract (stx-transfer? (var-get top-bid) (as-contract tx-sender) (var-get owner)))
+      ERR-NO-BIDS)))
 
 ;; public functions
 ;;
+;; Function to cancel the auction (only by owner, only if no bids)
+(define-public (cancel-auction)
+  (begin
+    ;; Check if sender is owner
+    (asserts! (is-eq tx-sender (var-get owner)) ERR-NOT-AUTHORIZED)
+    ;; Check that no bids have been placed
+    (asserts! (is-none (var-get top-bidder)) ERR-AUCTION-IN-PROGRESS)
+    ;; Reset auction data
+    (var-set auction-start-block u0)
+    (var-set auction-end-block u0)
+    (var-set top-bid u0)
+    (var-set top-bidder none)
+    (ok true)))
+
+;; read only functions
+;;
+;; Read-only functions
+(define-read-only (query-top-bid)
+  (ok (var-get top-bid)))
+
+;; private functions
+;;
+(define-read-only (query-top-bidder)
+  (ok (var-get top-bidder)))
+
+(define-read-only (query-auction-end)
+  (ok (var-get auction-end-block)))
+
+(define-read-only (query-item-name)
+  (ok (var-get item-name)))
+
+(define-read-only (query-reserve-price)
+  (ok (var-get reserve-price)))
+
+(define-read-only (query-auction-status)
+  (if (< block-height (var-get auction-start-block))
+      (ok "Not started")
+      (if (< block-height (var-get auction-end-block))
+          (ok "In progress")
+          (ok "Ended"))))


### PR DESCRIPTION


##  Pull Request: STX Auction Smart Contract

### 📋 Summary

This PR introduces a complete implementation of a **Clarity-based STX Auction Smart Contract** designed for the Stacks blockchain. It enables an auction owner to list an item for bidding with a reserve price and time duration, while participants can place bids using STX. The highest bidder at auction end wins the item and the funds are transferred to the auction owner. The contract ensures bid validation, safe fund transfers, and auction state integrity.

---

### 🚀 Features

* ✅ Owner-only auction initialization with duration, reserve price, and item name.
* ✅ Enforces minimum bid increment of **1 STX** (`BID-STEP`).
* ✅ Refunds previous highest bidder automatically on new top bid.
* ✅ Publicly accessible `conclude-auction` function ensures transparency and decentralization.
* ✅ Allows auction cancellation by the owner only when **no bids have been placed**.
* ✅ On-chain tracking of:

  * Top bid
  * Top bidder
  * Auction start and end block
  * Item name
  * Reserve price
* ✅ Read-only functions for easy frontend and explorer integration.

---

### 🔐 Access Control

* Only the **owner** (contract deployer) can:

  * Initialize the auction.
  * Cancel the auction.
* Any user can:

  * Submit a bid.
  * Conclude the auction (if criteria are met).

---

### 💸 Bidding Logic

* First valid bid must meet or exceed the reserve price.
* Subsequent bids must be **at least 1 STX higher** than the current top bid.
* Funds are transferred to the contract and previous bidder is refunded upon being outbid.

---

### 📤 Auction Conclusion

* Can be concluded by anyone **after auction end block**.
* Auction must:

  * Be ended (`block-height >= auction-end-block`)
  * Have at least one bid
  * Have top bid ≥ reserve price
* Upon success, top bid amount is transferred to the auction owner.

---

### ❌ Auction Cancellation

* Can only be done by the owner.
* Only allowed if **no bids have been placed**.

---

### 🧪 Read-Only View Functions

| Function               | Returns                                                    |
| ---------------------- | ---------------------------------------------------------- |
| `query-top-bid`        | Current highest bid (in micro-STX)                         |
| `query-top-bidder`     | Optional principal of highest bidder                       |
| `query-auction-end`    | Auction end block                                          |
| `query-item-name`      | Auctioned item name                                        |
| `query-reserve-price`  | Minimum reserve price                                      |
| `query-auction-status` | Auction state: `"Not started"`, `"In progress"`, `"Ended"` |

---

### 🧱 Error Handling

The contract defines precise error codes for predictable failure behavior:

| Code   | Meaning                            |
| ------ | ---------------------------------- |
| `u100` | Not authorized                     |
| `u101` | Auction already started            |
| `u102` | Auction not started                |
| `u103` | Auction already ended              |
| `u104` | Bid too low                        |
| `u105` | STX transfer failed                |
| `u106` | Auction not ended                  |
| `u107` | No bids available                  |
| `u108` | Invalid duration                   |
| `u109` | Reserve price not met              |
| `u110` | Auction in progress (can't cancel) |
| `u111` | Invalid item name length           |
| `u112` | Invalid reserve price              |

---

### 📌 Deployment Notes

* Ensure `tx-sender` is the intended auction owner at deployment.
* Amounts are handled in **micro-STX** (`1 STX = 1_000_000`).
* Block durations are approximate (1 block ≈ 10 minutes on Stacks).

---
